### PR TITLE
feat: Do light validations + batch signature verifications during replications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ alloy-primitives = "0.8.14"
 alloy-contract = "0.8.0"
 alloy-signer = "0.8.0"
 alloy-signer-local = "0.8.0"
-ed25519-dalek = "2.1.1"
+ed25519-dalek = { version = "2.1.1", features = ["batch"] }
 pre-commit = "0.5.2"
 rocksdb = {git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev="1cf906dc4087f06631820f13855e6b27bd21b972", features=["multi-threaded-cf"]}
 walkdir = "2.5.0"

--- a/src/core/validations/message.rs
+++ b/src/core/validations/message.rs
@@ -238,7 +238,7 @@ fn validate_signature(
     Ok(())
 }
 
-fn validate_message_hash(
+pub fn validate_message_hash(
     hash_scheme: i32,
     data_bytes: &Vec<u8>,
     hash: &Vec<u8>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use snapchain::utils::statsd_wrapper::StatsdClientWrapper;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::net::SocketAddr;
-use std::process::{self, exit};
+use std::process;
 use std::sync::Arc;
 use std::{fs, net};
 use tokio::net::TcpListener;


### PR DESCRIPTION
During replication, only verify the hash and the signature. Additionally, use batch verifications to take advantage of the large number of messages to speed up signature verifications